### PR TITLE
refactor/product: DTO에 toEntity()/from() 메서드 추가

### DIFF
--- a/src/main/java/com/sparta/twotwo/ai/controller/AIController.java
+++ b/src/main/java/com/sparta/twotwo/ai/controller/AIController.java
@@ -4,7 +4,7 @@ import com.sparta.twotwo.ai.dto.AIRequestLogResponseDto;
 import com.sparta.twotwo.ai.entity.AIRequestLog;
 import com.sparta.twotwo.ai.service.AIService;
 import com.sparta.twotwo.common.response.ApiResponse;
-import com.sparta.twotwo.product.entity.Product;
+import com.sparta.twotwo.product.entity.ProductEntity;
 import com.sparta.twotwo.product.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -22,7 +22,7 @@ public class AIController {
 
     @PostMapping("/generate/{productId}")
     public ResponseEntity<ApiResponse<AIRequestLogResponseDto>> generateDescription(@PathVariable UUID productId) {
-        Product product = productRepository.findById(productId)
+        ProductEntity product = productRepository.findById(productId)
                 .orElseThrow(() -> new IllegalArgumentException("상품을 찾을 수 없습니다: " + productId));
 
         AIRequestLog aiRequestLog = aiService.generateProductDescription(product);

--- a/src/main/java/com/sparta/twotwo/ai/entity/AIRequestLog.java
+++ b/src/main/java/com/sparta/twotwo/ai/entity/AIRequestLog.java
@@ -2,7 +2,7 @@ package com.sparta.twotwo.ai.entity;
 
 import com.sparta.twotwo.common.auditing.AuditableEntity;
 import com.sparta.twotwo.enums.AIRequestStatus;
-import com.sparta.twotwo.product.entity.Product;
+import com.sparta.twotwo.product.entity.ProductEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -27,7 +27,7 @@ public class AIRequestLog extends AuditableEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id", nullable = false)
-    private Product product;
+    private ProductEntity product;
 
     @Column(name = "request_text", columnDefinition = "TEXT", nullable = false)
     private String requestText;

--- a/src/main/java/com/sparta/twotwo/ai/service/AIService.java
+++ b/src/main/java/com/sparta/twotwo/ai/service/AIService.java
@@ -6,7 +6,7 @@ import com.sparta.twotwo.ai.config.GeminiConfig;
 import com.sparta.twotwo.ai.entity.AIRequestLog;
 import com.sparta.twotwo.ai.repository.AIRequestLogRepository;
 import com.sparta.twotwo.enums.AIRequestStatus;
-import com.sparta.twotwo.product.entity.Product;
+import com.sparta.twotwo.product.entity.ProductEntity;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.*;
@@ -25,7 +25,7 @@ public class AIService {
     private static final String API_URL = "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent";
 
     @Transactional
-    public AIRequestLog generateProductDescription(Product product) {
+    public AIRequestLog generateProductDescription(ProductEntity product) {
         AIRequestLog aiRequestLog = new AIRequestLog();
         aiRequestLog.setProduct(product);
 

--- a/src/main/java/com/sparta/twotwo/ai/service/AIService.java
+++ b/src/main/java/com/sparta/twotwo/ai/service/AIService.java
@@ -28,8 +28,6 @@ public class AIService {
     public AIRequestLog generateProductDescription(Product product) {
         AIRequestLog aiRequestLog = new AIRequestLog();
         aiRequestLog.setProduct(product);
-//        aiRequestLog.setRequestText(prompt);
-//        aiRequestLog.setStatus(AIRequestStatus.PENDING);
 
         // 요청 프롬포트 생성
         String finalPrompt = String.format(
@@ -68,7 +66,6 @@ public class AIService {
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
-//        headers.set("Authorization", "Bearer " + API_KEY);
 
         String requestBody = String.format(
                 "{\"contents\":[{\"parts\":[{\"text\":\"%s\"}]}]}",

--- a/src/main/java/com/sparta/twotwo/common/auditing/AuditableEntity.java
+++ b/src/main/java/com/sparta/twotwo/common/auditing/AuditableEntity.java
@@ -19,24 +19,24 @@ public class AuditableEntity {
     @CreatedDate
     @Column(name = "created_at", updatable = false)
     @Temporal(TemporalType.TIMESTAMP)
-    private LocalDateTime createdAt;
+    protected LocalDateTime createdAt;
 
     @LastModifiedDate
     @Column(name = "updated_at")
     @Temporal(TemporalType.TIMESTAMP)
-    private LocalDateTime updatedAt;
+    protected LocalDateTime updatedAt;
 
     @CreatedBy
     @Column(name = "created_by", updatable = false)
-    private Long createdBy;
+    protected Long createdBy;
 
     @LastModifiedBy
     @Column(name = "updated_by")
-    private Long updatedBy;
+    protected Long updatedBy;
 
     @Column(name = "deleted_at")
-    private LocalDateTime deletedAt;
+    protected LocalDateTime deletedAt;
 
     @Column(name = "deleted_by")
-    private Long deletedBy;
+    protected Long deletedBy;
 }

--- a/src/main/java/com/sparta/twotwo/order/dto/OrderProductDto.java
+++ b/src/main/java/com/sparta/twotwo/order/dto/OrderProductDto.java
@@ -1,7 +1,5 @@
 package com.sparta.twotwo.order.dto;
 
-import com.sparta.twotwo.order.entity.Order;
-import com.sparta.twotwo.product.entity.Product;
 import lombok.Builder;
 import lombok.Getter;
 

--- a/src/main/java/com/sparta/twotwo/order/dto/OrderProductRequestDto.java
+++ b/src/main/java/com/sparta/twotwo/order/dto/OrderProductRequestDto.java
@@ -2,7 +2,7 @@ package com.sparta.twotwo.order.dto;
 
 import com.sparta.twotwo.order.entity.Order;
 import com.sparta.twotwo.order.entity.OrderProduct;
-import com.sparta.twotwo.product.entity.Product;
+import com.sparta.twotwo.product.entity.ProductEntity;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -15,7 +15,7 @@ public class OrderProductRequestDto {
     private Long quantity;
     private UUID productId;
 
-    public OrderProduct toEntity(Order order, Product product){
+    public OrderProduct toEntity(Order order, ProductEntity product){
         return OrderProduct.builder()
                 .order(order)
                 .product(product)

--- a/src/main/java/com/sparta/twotwo/order/dto/OrderRequestDto.java
+++ b/src/main/java/com/sparta/twotwo/order/dto/OrderRequestDto.java
@@ -4,14 +4,13 @@ import com.sparta.twotwo.enums.OrderType;
 import com.sparta.twotwo.members.entity.Member;
 import com.sparta.twotwo.order.entity.Order;
 import com.sparta.twotwo.order.entity.OrderProduct;
-import com.sparta.twotwo.product.entity.Product;
+import com.sparta.twotwo.product.entity.ProductEntity;
 import com.sparta.twotwo.store.entity.Store;
 import lombok.Getter;
 import lombok.Setter;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 @Getter
 @Setter
@@ -33,7 +32,7 @@ public class OrderRequestDto {
                 .build();
     }
 
-    public OrderProduct toOrderProductEntity(Order order, Product product){
+    public OrderProduct toOrderProductEntity(Order order, ProductEntity product){
         return OrderProduct.builder()
                 .order(order)
                 .product(product)

--- a/src/main/java/com/sparta/twotwo/order/entity/OrderProduct.java
+++ b/src/main/java/com/sparta/twotwo/order/entity/OrderProduct.java
@@ -2,9 +2,8 @@ package com.sparta.twotwo.order.entity;
 
 
 import com.sparta.twotwo.common.auditing.BaseEntity;
-import com.sparta.twotwo.enums.OrderType;
 import com.sparta.twotwo.order.dto.OrderProductDto;
-import com.sparta.twotwo.product.entity.Product;
+import com.sparta.twotwo.product.entity.ProductEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.GenericGenerator;
@@ -22,7 +21,7 @@ import java.util.UUID;
 public class OrderProduct extends BaseEntity {
 
     @Builder
-    public OrderProduct(Order order, Product product, Long quantity){
+    public OrderProduct(Order order, ProductEntity product, Long quantity){
         this.order = order;
         this.product = product;
         this.quantity = quantity;
@@ -40,7 +39,7 @@ public class OrderProduct extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "id")
-    private Product product;
+    private ProductEntity product;
 
     @Column(name = "quantity", nullable = false)
     private Long quantity;
@@ -52,7 +51,7 @@ public class OrderProduct extends BaseEntity {
     public void changeQuantity(Long quantity) {
         this.quantity = quantity;
     }
-    public void changeProduct(Product product) {
+    public void changeProduct(ProductEntity product) {
         this.product = product;
     }
 

--- a/src/main/java/com/sparta/twotwo/order/service/OrderService.java
+++ b/src/main/java/com/sparta/twotwo/order/service/OrderService.java
@@ -13,7 +13,7 @@ import com.sparta.twotwo.order.entity.Order;
 import com.sparta.twotwo.order.entity.OrderProduct;
 import com.sparta.twotwo.order.repository.OrderProductRepository;
 import com.sparta.twotwo.order.repository.OrderRepository;
-import com.sparta.twotwo.product.entity.Product;
+import com.sparta.twotwo.product.entity.ProductEntity;
 import com.sparta.twotwo.product.repository.ProductRepository;
 import com.sparta.twotwo.store.entity.Store;
 import com.sparta.twotwo.store.repository.StoreRepository;
@@ -58,7 +58,7 @@ public class OrderService {
 
         Long totalPrice = 0L;
         for(OrderProductRequestDto dto : orderProductRequestDtos) {
-            Product product = productRepository.findById(dto.getProductId())
+            ProductEntity product = productRepository.findById(dto.getProductId())
                     .orElseThrow(()-> new TwotwoApplicationException(ErrorCode.ORDER_NOT_FOUND));
 
             OrderProduct orderProduct = OrderProduct.builder()
@@ -121,7 +121,7 @@ public class OrderService {
         Long prevPrice = orderProduct.getQuantity() * orderProduct.getProduct().getPrice();
 
 
-        Product product = productRepository.findById(orderProductRequestDto.getProductId())
+        ProductEntity product = productRepository.findById(orderProductRequestDto.getProductId())
                 .orElseThrow(()->new TwotwoApplicationException(ErrorCode.PRODUCT_NOT_FOUND));
         orderProduct.changeProduct(product);
         orderProduct.changeQuantity(orderProductRequestDto.getQuantity());

--- a/src/main/java/com/sparta/twotwo/product/controller/ProductController.java
+++ b/src/main/java/com/sparta/twotwo/product/controller/ProductController.java
@@ -1,7 +1,9 @@
 package com.sparta.twotwo.product.controller;
 
 import com.sparta.twotwo.common.response.ApiResponse;
-import com.sparta.twotwo.product.dto.*;
+import com.sparta.twotwo.product.dto.request.ProductRequestDto;
+import com.sparta.twotwo.product.dto.request.ProductUpdateRequestDto;
+import com.sparta.twotwo.product.dto.response.*;
 import com.sparta.twotwo.product.service.ProductService;
 import com.sparta.twotwo.product.service.S3Service;
 import jakarta.validation.Valid;

--- a/src/main/java/com/sparta/twotwo/product/dto/ProductRequestDto.java
+++ b/src/main/java/com/sparta/twotwo/product/dto/ProductRequestDto.java
@@ -1,5 +1,7 @@
 package com.sparta.twotwo.product.dto;
 
+import com.sparta.twotwo.product.entity.Product;
+import com.sparta.twotwo.store.entity.Store;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -14,7 +16,7 @@ public class ProductRequestDto {
     @NotNull
     private UUID storeId;
 
-    private String description; //설명 수동 입력 가능 (?)
+    private String description;
 
     @NotBlank
     private String productName;
@@ -24,4 +26,13 @@ public class ProductRequestDto {
 
     private String imageUrl;
 
+    public Product toEntity(Store store, Long createdBy) {
+        return new Product(
+                store,
+                productName,
+                price,
+                imageUrl,
+                createdBy
+        );
+    }
 }

--- a/src/main/java/com/sparta/twotwo/product/dto/ProductResponseDto.java
+++ b/src/main/java/com/sparta/twotwo/product/dto/ProductResponseDto.java
@@ -1,9 +1,11 @@
 package com.sparta.twotwo.product.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.sparta.twotwo.product.entity.Product;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 
 @Getter
@@ -21,4 +23,17 @@ public class ProductResponseDto {
     private Long createdBy;
     private String updatedAt;
     private Long updatedBy;
+
+    public static ProductResponseDto from(Product product) {
+        return ProductResponseDto.builder()
+                .productId(product.getId())
+                .storeId(product.getStore().getId())
+                .description(product.getDescription())
+                .productName(product.getProductName())
+                .price(product.getPrice())
+                .imageUrl(product.getImageUrl())
+                .createdAt(product.getCreatedAt().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+                .createdBy(product.getCreatedBy())
+                .build();
+    }
 }

--- a/src/main/java/com/sparta/twotwo/product/dto/request/ProductRequestDto.java
+++ b/src/main/java/com/sparta/twotwo/product/dto/request/ProductRequestDto.java
@@ -1,6 +1,6 @@
-package com.sparta.twotwo.product.dto;
+package com.sparta.twotwo.product.dto.request;
 
-import com.sparta.twotwo.product.entity.Product;
+import com.sparta.twotwo.product.entity.ProductEntity;
 import com.sparta.twotwo.store.entity.Store;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -26,8 +26,8 @@ public class ProductRequestDto {
 
     private String imageUrl;
 
-    public Product toEntity(Store store, Long createdBy) {
-        return new Product(
+    public ProductEntity toEntity(Store store, Long createdBy) {
+        return new ProductEntity(
                 store,
                 productName,
                 price,

--- a/src/main/java/com/sparta/twotwo/product/dto/request/ProductUpdateRequestDto.java
+++ b/src/main/java/com/sparta/twotwo/product/dto/request/ProductUpdateRequestDto.java
@@ -1,4 +1,4 @@
-package com.sparta.twotwo.product.dto;
+package com.sparta.twotwo.product.dto.request;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/sparta/twotwo/product/dto/response/PresignedUrlResponseDto.java
+++ b/src/main/java/com/sparta/twotwo/product/dto/response/PresignedUrlResponseDto.java
@@ -1,4 +1,4 @@
-package com.sparta.twotwo.product.dto;
+package com.sparta.twotwo.product.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src/main/java/com/sparta/twotwo/product/dto/response/ProductDeleteResponseDto.java
+++ b/src/main/java/com/sparta/twotwo/product/dto/response/ProductDeleteResponseDto.java
@@ -1,4 +1,4 @@
-package com.sparta.twotwo.product.dto;
+package com.sparta.twotwo.product.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/sparta/twotwo/product/dto/response/ProductListResponseDto.java
+++ b/src/main/java/com/sparta/twotwo/product/dto/response/ProductListResponseDto.java
@@ -1,4 +1,4 @@
-package com.sparta.twotwo.product.dto;
+package com.sparta.twotwo.product.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/sparta/twotwo/product/dto/response/ProductMenuResponseDto.java
+++ b/src/main/java/com/sparta/twotwo/product/dto/response/ProductMenuResponseDto.java
@@ -1,6 +1,6 @@
-package com.sparta.twotwo.product.dto;
+package com.sparta.twotwo.product.dto.response;
 
-import com.sparta.twotwo.product.entity.Product;
+import com.sparta.twotwo.product.entity.ProductEntity;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -17,7 +17,7 @@ public class ProductMenuResponseDto {
     private final String imageUrl;
     private final boolean isHidden;
 
-    public static ProductMenuResponseDto from(Product product) {
+    public static ProductMenuResponseDto from(ProductEntity product) {
         return new ProductMenuResponseDto(
                 product.getId(),
                 product.getProductName(),

--- a/src/main/java/com/sparta/twotwo/product/dto/response/ProductResponseDto.java
+++ b/src/main/java/com/sparta/twotwo/product/dto/response/ProductResponseDto.java
@@ -1,7 +1,7 @@
-package com.sparta.twotwo.product.dto;
+package com.sparta.twotwo.product.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.sparta.twotwo.product.entity.Product;
+import com.sparta.twotwo.product.entity.ProductEntity;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -24,7 +24,7 @@ public class ProductResponseDto {
     private String updatedAt;
     private Long updatedBy;
 
-    public static ProductResponseDto from(Product product) {
+    public static ProductResponseDto from(ProductEntity product) {
         return ProductResponseDto.builder()
                 .productId(product.getId())
                 .storeId(product.getStore().getId())

--- a/src/main/java/com/sparta/twotwo/product/dto/response/ProductUpdateResponseDto.java
+++ b/src/main/java/com/sparta/twotwo/product/dto/response/ProductUpdateResponseDto.java
@@ -1,4 +1,4 @@
-package com.sparta.twotwo.product.dto;
+package com.sparta.twotwo.product.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/sparta/twotwo/product/entity/Product.java
+++ b/src/main/java/com/sparta/twotwo/product/entity/Product.java
@@ -61,4 +61,9 @@ public class Product extends BaseEntity {
         this.createdBy = createdBy;
         this.createdAt = LocalDateTime.now();
     }
+
+    public void addAiDescription(AIRequestLog aiRequestLog) {
+        this.descriptionLog = aiRequestLog; // ai 요청
+        this.description = aiRequestLog.getResponseText(); // ai 응답
+    }
 }

--- a/src/main/java/com/sparta/twotwo/product/entity/Product.java
+++ b/src/main/java/com/sparta/twotwo/product/entity/Product.java
@@ -11,6 +11,7 @@ import lombok.Setter;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Getter
@@ -45,4 +46,19 @@ public class Product extends BaseEntity {
 
     @Column(name = "image_url", length = 200)
     private String imageUrl;
+
+    public Product(
+            Store store,
+            String productName,
+            int price,
+            String imageUrl,
+            Long createdBy
+    ) {
+        this.store = store;
+        this.productName = productName;
+        this.price = price;
+        this.imageUrl = imageUrl;
+        this.createdBy = createdBy;
+        this.createdAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/sparta/twotwo/product/entity/ProductEntity.java
+++ b/src/main/java/com/sparta/twotwo/product/entity/ProductEntity.java
@@ -20,7 +20,7 @@ import java.util.UUID;
 @AllArgsConstructor
 @Entity
 @Table(name = "p_product")
-public class Product extends BaseEntity {
+public class ProductEntity extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     @JdbcTypeCode(SqlTypes.BINARY)
@@ -47,7 +47,7 @@ public class Product extends BaseEntity {
     @Column(name = "image_url", length = 200)
     private String imageUrl;
 
-    public Product(
+    public ProductEntity(
             Store store,
             String productName,
             int price,

--- a/src/main/java/com/sparta/twotwo/product/entity/ProductPrice.java
+++ b/src/main/java/com/sparta/twotwo/product/entity/ProductPrice.java
@@ -1,0 +1,16 @@
+package com.sparta.twotwo.product.entity;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.AccessType;
+
+@Getter
+@Embeddable
+@AccessType(AccessType.Type.FIELD)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ProductPrice {
+}

--- a/src/main/java/com/sparta/twotwo/product/repository/ProductRepository.java
+++ b/src/main/java/com/sparta/twotwo/product/repository/ProductRepository.java
@@ -1,6 +1,6 @@
 package com.sparta.twotwo.product.repository;
 
-import com.sparta.twotwo.product.entity.Product;
+import com.sparta.twotwo.product.entity.ProductEntity;
 import com.sparta.twotwo.store.entity.Store;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -10,7 +10,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 @Repository
-public interface ProductRepository extends JpaRepository<Product, UUID>, ProductSearchRepository {
-    List<Product> findByStoreAndIsDeletedFalse(Store store);
-    Optional<Product> findByIdAndIsDeletedFalse(UUID id);
+public interface ProductRepository extends JpaRepository<ProductEntity, UUID>, ProductSearchRepository {
+    List<ProductEntity> findByStoreAndIsDeletedFalse(Store store);
+    Optional<ProductEntity> findByIdAndIsDeletedFalse(UUID id);
 }

--- a/src/main/java/com/sparta/twotwo/product/repository/ProductSearchRepository.java
+++ b/src/main/java/com/sparta/twotwo/product/repository/ProductSearchRepository.java
@@ -1,6 +1,6 @@
 package com.sparta.twotwo.product.repository;
 
-import com.sparta.twotwo.product.dto.ProductListResponseDto;
+import com.sparta.twotwo.product.dto.response.ProductListResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 

--- a/src/main/java/com/sparta/twotwo/product/repository/ProductSearchRepositoryImpl.java
+++ b/src/main/java/com/sparta/twotwo/product/repository/ProductSearchRepositoryImpl.java
@@ -3,8 +3,8 @@ package com.sparta.twotwo.product.repository;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.QueryResults;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.sparta.twotwo.product.dto.ProductListResponseDto;
-import com.sparta.twotwo.product.entity.Product;
+import com.sparta.twotwo.product.dto.response.ProductListResponseDto;
+import com.sparta.twotwo.product.entity.ProductEntity;
 import com.sparta.twotwo.product.entity.QProduct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -40,7 +40,7 @@ public class ProductSearchRepositoryImpl implements ProductSearchRepository {
             orderBy = sortBy.equals("updatedAt") ? product.updatedAt.asc() : product.createdAt.asc();
         }
 
-        QueryResults<Product> results = queryFactory
+        QueryResults<ProductEntity> results = queryFactory
                 .selectFrom(product)
                 .where(builder)
                 .orderBy(orderBy)

--- a/src/main/java/com/sparta/twotwo/product/service/ProductService.java
+++ b/src/main/java/com/sparta/twotwo/product/service/ProductService.java
@@ -3,7 +3,6 @@ package com.sparta.twotwo.product.service;
 import com.sparta.twotwo.ai.entity.AIRequestLog;
 import com.sparta.twotwo.ai.service.AIService;
 import com.sparta.twotwo.auth.util.SecurityUtil;
-import com.sparta.twotwo.enums.AIRequestStatus;
 import com.sparta.twotwo.product.dto.*;
 import com.sparta.twotwo.product.entity.Product;
 import com.sparta.twotwo.product.repository.ProductRepository;
@@ -65,19 +64,8 @@ public class ProductService {
         reqProduct.addAiDescription(aiRequestLog);
         Product savedProduct = productRepository.save(reqProduct);
 
-
-        return ProductResponseDto.builder()
-                .productId(reqProduct.getId())
-                .storeId(reqProduct.getStore().getId())
-                .description(reqProduct.getDescription())
-                .productName(reqProduct.getProductName())
-                .price(reqProduct.getPrice())
-                .imageUrl(reqProduct.getImageUrl())
-                .createdAt(reqProduct.getCreatedAt().format(FORMATTER))
-                .createdBy(reqProduct.getCreatedBy())
-                .build();
+        return ProductResponseDto.from(savedProduct);
     }
-
 
     @Transactional(readOnly = true)
     public List<ProductListResponseDto> getProductsByStoreId(UUID storeId) {

--- a/src/main/java/com/sparta/twotwo/product/service/ProductService.java
+++ b/src/main/java/com/sparta/twotwo/product/service/ProductService.java
@@ -53,11 +53,10 @@ public class ProductService {
         return productRepository.searchProducts(keyword, minPrice, maxPrice, sortBy, sortDirection, pageable);
     }
 
+    // 상품 등록
     @Transactional
     public ProductResponseDto createProduct(ProductRequestDto requestDto) {
-        Store store = storeRepository.findById(requestDto.getStoreId())
-                .orElseThrow(() -> new IllegalArgumentException("해당 가게가 존재하지 않습니다: " + requestDto.getStoreId()));
-
+        Store store = findStore(requestDto.getStoreId());
         Long createdBy = authenticateMember();
 
         if (requestDto.getPrice() < 0) {
@@ -97,9 +96,7 @@ public class ProductService {
 
     @Transactional(readOnly = true)
     public List<ProductListResponseDto> getProductsByStoreId(UUID storeId) {
-        Store store = storeRepository.findById(storeId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 가게가 존재하지 않습니다: " + storeId));
-
+        Store store = findStore(storeId);
         List<Product> products = productRepository.findByStoreAndIsDeletedFalse(store);
 
         if (products.isEmpty()) {
@@ -142,9 +139,7 @@ public class ProductService {
 
     @Transactional
     public ProductUpdateResponseDto updateProduct(UUID productId, ProductUpdateRequestDto requestDto) {
-        Product product = productRepository.findById(productId)
-                .orElseThrow(() -> new IllegalArgumentException("상품을 찾을 수 없습니다: " + productId));
-
+        Product product = findProduct(productId);
         Long updatedBy = authenticateMember();
 
         if (requestDto.getProductName() != null) {
@@ -180,8 +175,7 @@ public class ProductService {
 
     @Transactional
     public ProductDeleteResponseDto deleteProduct(UUID productId) {
-        Product product = productRepository.findById(productId)
-                .orElseThrow(() -> new IllegalArgumentException("상품을 찾을 수 없습니다: " + productId));
+        Product product = findProduct(productId);
 
         Long deletedBy = authenticateMember();
 
@@ -195,5 +189,17 @@ public class ProductService {
                 .deletedAt(product.getDeletedAt().format(FORMATTER))
                 .deletedBy(deletedBy)
                 .build();
+    }
+
+    /// ////////////////////////////////////////////////
+
+    private Product findProduct(UUID productId) {
+        return productRepository.findById(productId)
+                .orElseThrow(() -> new IllegalArgumentException("상품을 찾을 수 없습니다: " + productId));
+    }
+
+    private Store findStore(UUID storeId) {
+        return storeRepository.findById(storeId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 가게가 존재하지 않습니다: " + storeId));
     }
 }

--- a/src/main/java/com/sparta/twotwo/product/service/ProductService.java
+++ b/src/main/java/com/sparta/twotwo/product/service/ProductService.java
@@ -3,8 +3,13 @@ package com.sparta.twotwo.product.service;
 import com.sparta.twotwo.ai.entity.AIRequestLog;
 import com.sparta.twotwo.ai.service.AIService;
 import com.sparta.twotwo.auth.util.SecurityUtil;
-import com.sparta.twotwo.product.dto.*;
-import com.sparta.twotwo.product.entity.Product;
+import com.sparta.twotwo.product.dto.request.ProductRequestDto;
+import com.sparta.twotwo.product.dto.request.ProductUpdateRequestDto;
+import com.sparta.twotwo.product.dto.response.ProductDeleteResponseDto;
+import com.sparta.twotwo.product.dto.response.ProductListResponseDto;
+import com.sparta.twotwo.product.dto.response.ProductResponseDto;
+import com.sparta.twotwo.product.dto.response.ProductUpdateResponseDto;
+import com.sparta.twotwo.product.entity.ProductEntity;
 import com.sparta.twotwo.product.repository.ProductRepository;
 import com.sparta.twotwo.store.entity.Store;
 import com.sparta.twotwo.store.repository.StoreRepository;
@@ -58,11 +63,11 @@ public class ProductService {
         Store store = findStore(requestDto.getStoreId());
         Long createdBy = authenticateMember();
 
-        Product reqProduct = requestDto.toEntity(store, createdBy);
+        ProductEntity reqProduct = requestDto.toEntity(store, createdBy);
         AIRequestLog aiRequestLog = aiService.generateProductDescription(reqProduct);
 
         reqProduct.addAiDescription(aiRequestLog);
-        Product savedProduct = productRepository.save(reqProduct);
+        ProductEntity savedProduct = productRepository.save(reqProduct);
 
         return ProductResponseDto.from(savedProduct);
     }
@@ -70,7 +75,7 @@ public class ProductService {
     @Transactional(readOnly = true)
     public List<ProductListResponseDto> getProductsByStoreId(UUID storeId) {
         Store store = findStore(storeId);
-        List<Product> products = productRepository.findByStoreAndIsDeletedFalse(store);
+        List<ProductEntity> products = productRepository.findByStoreAndIsDeletedFalse(store);
 
         if (products.isEmpty()) {
             throw new IllegalArgumentException("해당 가게에 등록된 상품이 없습니다.");
@@ -91,7 +96,7 @@ public class ProductService {
 
     @Transactional(readOnly = true)
     public ProductResponseDto getProductById(UUID productId) {
-        Product product = productRepository.findByIdAndIsDeletedFalse(productId)
+        ProductEntity product = productRepository.findByIdAndIsDeletedFalse(productId)
                 .orElseThrow(() -> new IllegalArgumentException("상품을 찾을 수 없습니다. 삭제되었거나 존재하지 않는 상품입니다: " + productId));
 
         return ProductResponseDto.builder()
@@ -112,7 +117,7 @@ public class ProductService {
 
     @Transactional
     public ProductUpdateResponseDto updateProduct(UUID productId, ProductUpdateRequestDto requestDto) {
-        Product product = findProduct(productId);
+        ProductEntity product = findProduct(productId);
         Long updatedBy = authenticateMember();
 
         if (requestDto.getProductName() != null) {
@@ -148,7 +153,7 @@ public class ProductService {
 
     @Transactional
     public ProductDeleteResponseDto deleteProduct(UUID productId) {
-        Product product = findProduct(productId);
+        ProductEntity product = findProduct(productId);
 
         Long deletedBy = authenticateMember();
 
@@ -166,7 +171,7 @@ public class ProductService {
 
     /// ////////////////////////////////////////////////
 
-    private Product findProduct(UUID productId) {
+    private ProductEntity findProduct(UUID productId) {
         return productRepository.findById(productId)
                 .orElseThrow(() -> new IllegalArgumentException("상품을 찾을 수 없습니다: " + productId));
     }

--- a/src/main/java/com/sparta/twotwo/store/dto/response/StoreDetailResponseDto.java
+++ b/src/main/java/com/sparta/twotwo/store/dto/response/StoreDetailResponseDto.java
@@ -1,7 +1,7 @@
 package com.sparta.twotwo.store.dto.response;
 
 import com.sparta.twotwo.address.dto.response.AddressResponseDto;
-import com.sparta.twotwo.product.dto.ProductMenuResponseDto;
+import com.sparta.twotwo.product.dto.response.ProductMenuResponseDto;
 import com.sparta.twotwo.store.entity.Store;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/sparta/twotwo/store/entity/Store.java
+++ b/src/main/java/com/sparta/twotwo/store/entity/Store.java
@@ -3,7 +3,7 @@ package com.sparta.twotwo.store.entity;
 import com.sparta.twotwo.address.entity.Address;
 import com.sparta.twotwo.common.auditing.BaseEntity;
 import com.sparta.twotwo.members.entity.Member;
-import com.sparta.twotwo.product.entity.Product;
+import com.sparta.twotwo.product.entity.ProductEntity;
 import com.sparta.twotwo.review.entity.Review;
 import jakarta.persistence.*;
 import lombok.*;
@@ -43,7 +43,7 @@ public class Store extends BaseEntity {
     private StoreCategory category;
 
     @OneToMany(mappedBy = "store", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Product> products = new ArrayList<>();
+    private List<ProductEntity> products = new ArrayList<>();
 
     @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "store_id")

--- a/src/main/java/com/sparta/twotwo/store/service/StoreService.java
+++ b/src/main/java/com/sparta/twotwo/store/service/StoreService.java
@@ -6,7 +6,7 @@ import com.sparta.twotwo.common.exception.ErrorCode;
 import com.sparta.twotwo.common.exception.TwotwoApplicationException;
 import com.sparta.twotwo.members.entity.Member;
 import com.sparta.twotwo.members.repository.MemberRepository;
-import com.sparta.twotwo.product.entity.Product;
+import com.sparta.twotwo.product.entity.ProductEntity;
 import com.sparta.twotwo.product.service.ProductService;
 import com.sparta.twotwo.store.dto.request.StoreSearchRequestDto;
 import com.sparta.twotwo.address.entity.Address;
@@ -144,9 +144,9 @@ public class StoreService {
         store.setDeletedBy(deleterId);
         store.setIsDeleted(Boolean.TRUE);
 
-        List<Product> products = store.getProducts();
+        List<ProductEntity> products = store.getProducts();
         if (products != null) {
-            for (Product product : products) {
+            for (ProductEntity product : products) {
                 productService.deleteProduct(product.getId());
             }
         }

--- a/src/test/java/com/sparta/twotwo/order/entity/OrderTest.java
+++ b/src/test/java/com/sparta/twotwo/order/entity/OrderTest.java
@@ -1,26 +1,6 @@
 package com.sparta.twotwo.order.entity;
 
-import com.sparta.twotwo.enums.OrderType;
-import com.sparta.twotwo.members.entity.Member;
-import com.sparta.twotwo.members.repository.MemberRepository;
-import com.sparta.twotwo.order.repository.OrderRepository;
-import com.sparta.twotwo.address.entity.Address;
-import com.sparta.twotwo.address.entity.Area;
-import com.sparta.twotwo.product.entity.Product;
-import com.sparta.twotwo.store.entity.Store;
-import com.sparta.twotwo.store.entity.StoreCategory;
-import com.sparta.twotwo.address.repository.AddressRepository;
-import com.sparta.twotwo.address.repository.AreaRepository;
-import com.sparta.twotwo.store.repository.StoreCategoryRepository;
-import com.sparta.twotwo.store.repository.StoreRepository;
-import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.UUID;
 
 
 @SpringBootTest


### PR DESCRIPTION
## 변경 내용
- ProductRequestDto에 toEntity() 메서드 추가
  - 서비스 계층의 객체 생성 책임을 DTO로 위임하여 SRP 개선

- ProductResponseDto에 from() 정적 팩토리 메서드 추가
  - Entity → DTO 변환 책임을 DTO 내부로 분리
  - 서비스 내 builder 호출 제거

## 효과
- 서비스 계층은 비즈니스 흐름만 담당하도록 책임 분리
- DTO 내부로 생성/변환 로직을 이동시켜 코드 응집도 향상
